### PR TITLE
fix: fix exit_epoch checks and fallback on FetchError

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start:prod": "NODE_OPTIONS='--max-old-space-size=8192 --experimental-vm-modules' node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test-daemon": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --config test/jest-daemon-e2e.json",
     "estimate-gas": "ts-node scripts/estimate-gas-cost.ts"

--- a/src/common/prometheus/prometheus.constants.ts
+++ b/src/common/prometheus/prometheus.constants.ts
@@ -58,6 +58,7 @@ export const METRIC_MEMORY_USAGE_BYTES = `memory_usage_bytes`;
 export const METRIC_EXIT_ALREADY_PROCESSED_COUNT = `exit_already_processed_count`;
 export const METRIC_EXIT_DEADLINE_MISSED_COUNT = `exit_deadline_missed_count`;
 export const METRIC_EXIT_DEADLINE_FUTURE_COUNT = `exit_deadline_future_count`;
+export const METRIC_EXIT_INITIATED_COUNT = `exit_initiated_count`;
 export const METRIC_BEACON_STATE_FETCH_DURATION_SECONDS = `beacon_state_fetch_duration_seconds`;
 export const METRIC_BEACON_STATE_DESERIALIZATION_DURATION_SECONDS = `beacon_state_deserialization_duration_seconds`;
 

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -23,6 +23,7 @@ import {
   METRIC_EXIT_ALREADY_PROCESSED_COUNT,
   METRIC_EXIT_DEADLINE_FUTURE_COUNT,
   METRIC_EXIT_DEADLINE_MISSED_COUNT,
+  METRIC_EXIT_INITIATED_COUNT,
   METRIC_EXIT_REQUESTS_FOUND_COUNT,
   METRIC_EXIT_REQUESTS_PROCESSED_COUNT,
   METRIC_HIGH_GAS_FEE_INTERRUPTIONS_COUNT,
@@ -342,6 +343,12 @@ export class PrometheusService {
   public exitDeadlineFutureCount = this.getOrCreateMetric('Counter', {
     name: METRIC_EXIT_DEADLINE_FUTURE_COUNT,
     help: 'Count of future exit deadlines',
+    labelNames: ['module_id'],
+  });
+
+  public exitInitiatedCount = this.getOrCreateMetric('Counter', {
+    name: METRIC_EXIT_INITIATED_COUNT,
+    help: 'Count of validators skipped because a CL exit was already initiated before the deadline',
     labelNames: ['module_id'],
   });
 

--- a/src/common/prover/prover.service.spec.ts
+++ b/src/common/prover/prover.service.spec.ts
@@ -17,7 +17,9 @@ const makePrometheusMock = () => ({
 const makeLogger = () => ({ log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() });
 
 // Minimal validator input as returned by decodeValidatorsData
-const makeValidatorInput = (overrides: Partial<{ validatorIndex: bigint; moduleId: bigint; nodeOpId: bigint; validatorPubkey: string }> = {}) => ({
+const makeValidatorInput = (
+  overrides: Partial<{ validatorIndex: bigint; moduleId: bigint; nodeOpId: bigint; validatorPubkey: string }> = {},
+) => ({
   validatorIndex: BigInt(1039010),
   moduleId: BigInt(1),
   nodeOpId: BigInt(42),
@@ -51,15 +53,15 @@ const makeService = (overrides: Record<string, any> = {}) => {
   };
 
   const service = new (ProverService as any)(
-    makeLogger(),            // loggerService
-    consensus,               // consensus
-    {},                      // exitRequests
-    {},                      // verifier
-    {},                      // stakingRouter
-    {},                      // execution
-    makePrometheusMock(),    // prometheus
-    {},                      // config
-    50,                      // validatorBatchSize
+    makeLogger(), // loggerService
+    consensus, // consensus
+    {}, // exitRequests
+    {}, // verifier
+    {}, // stakingRouter
+    {}, // execution
+    makePrometheusMock(), // prometheus
+    {}, // config
+    50, // validatorBatchSize
   );
 
   // Set private fields that are normally initialised in onModuleInit
@@ -84,7 +86,7 @@ describe('ProverService.processValidator - exit epoch filtering', () => {
       makeStateView(exitEpoch),
       PROOF_SLOT_TIMESTAMP,
       DELIVERED_TIMESTAMP,
-      0,   // fromBlock
+      0, // fromBlock
       100, // toBlock
     );
 

--- a/src/common/prover/prover.service.spec.ts
+++ b/src/common/prover/prover.service.spec.ts
@@ -1,0 +1,166 @@
+import { ProverService } from './prover.service';
+
+// Minimal prometheus mock covering every counter/timer used in processValidator
+const makePrometheusMock = () => ({
+  validatorProcessingDuration: { startTimer: jest.fn(() => jest.fn()) },
+  exitAlreadyProcessedCount: { inc: jest.fn() },
+  exitInitiatedCount: { inc: jest.fn() },
+  validatorsSkippedCount: { inc: jest.fn() },
+  exitDeadlineFutureCount: { inc: jest.fn() },
+  validatorsEligibleCount: { set: jest.fn() },
+  validatorsProcessedCount: { inc: jest.fn() },
+  validatorsPenaltyApplicableCount: { inc: jest.fn() },
+  proofGenerationDuration: { startTimer: jest.fn(() => jest.fn()) },
+  proofGenerationCount: { inc: jest.fn() },
+});
+
+const makeLogger = () => ({ log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() });
+
+// Minimal validator input as returned by decodeValidatorsData
+const makeValidatorInput = (overrides: Partial<{ validatorIndex: bigint; moduleId: bigint; nodeOpId: bigint; validatorPubkey: string }> = {}) => ({
+  validatorIndex: BigInt(1039010),
+  moduleId: BigInt(1),
+  nodeOpId: BigInt(42),
+  validatorPubkey: '0xaabbcc',
+  exitDataIndex: 0,
+  ...overrides,
+});
+
+// Minimal stateView mock: returns a validator with a given exitEpoch
+const makeStateView = (exitEpoch: number | typeof Infinity) => ({
+  validators: {
+    getReadonly: jest.fn(() => ({
+      exitEpoch,
+      withdrawalCredentials: new Uint8Array(32),
+      effectiveBalance: BigInt(32_000_000_000),
+      slashed: false,
+      activationEligibilityEpoch: 244578,
+      activationEpoch: 244687,
+      withdrawableEpoch: Infinity,
+    })),
+  },
+});
+
+// Build a ProverService instance with all deps stubbed out
+const makeService = (overrides: Record<string, any> = {}) => {
+  const consensus = {
+    genesisTimestamp: 1606824023,
+    beaconConfig: { SLOTS_PER_EPOCH: 32, SECONDS_PER_SLOT: 12 },
+    slotToTimestamp: jest.fn((slot: number) => 1606824023 + slot * 12),
+    ...overrides.consensus,
+  };
+
+  const service = new (ProverService as any)(
+    makeLogger(),            // loggerService
+    consensus,               // consensus
+    {},                      // exitRequests
+    {},                      // verifier
+    {},                      // stakingRouter
+    {},                      // execution
+    makePrometheusMock(),    // prometheus
+    {},                      // config
+    50,                      // validatorBatchSize
+  );
+
+  // Set private fields that are normally initialised in onModuleInit
+  service.SHARD_COMMITTEE_PERIOD_IN_SECONDS = 2_764_800; // 256 epochs × 32 slots × 12 s
+
+  return service;
+};
+
+// ─── processValidator — exit epoch filtering ──────────────────────────────────
+
+describe('ProverService.processValidator - exit epoch filtering', () => {
+  const DEADLINE_EPOCH = 443778; // epoch of deadline slot 14200917
+  const PROOF_SLOT_TIMESTAMP = 1_777_235_027; // timestamp of slot 14200917
+  const ACTIVATION_EPOCH = 244687;
+  const DELIVERED_TIMESTAMP = 1_776_000_000; // far enough in the past
+
+  const callProcessValidator = (service: any, exitEpoch: number | typeof Infinity) =>
+    (service as any).processValidator(
+      makeValidatorInput(),
+      ACTIVATION_EPOCH,
+      DEADLINE_EPOCH,
+      makeStateView(exitEpoch),
+      PROOF_SLOT_TIMESTAMP,
+      DELIVERED_TIMESTAMP,
+      0,   // fromBlock
+      100, // toBlock
+    );
+
+  it('returns null when exitEpoch < exitDeadlineEpoch (validator already exited before deadline)', async () => {
+    const service = makeService();
+    const result = await callProcessValidator(service, DEADLINE_EPOCH - 1);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when exitEpoch equals exitDeadlineEpoch (exited exactly at deadline boundary)', async () => {
+    const service = makeService();
+    const result = await callProcessValidator(service, DEADLINE_EPOCH);
+    // DEADLINE_EPOCH is NOT < DEADLINE_EPOCH, so falls through to the new Infinity check
+    // exitEpoch (443778) !== Infinity → skipped
+    expect(result).toBeNull();
+  });
+
+  it('returns null when exitEpoch > exitDeadlineEpoch but is not Infinity (exit initiated after deadline)', async () => {
+    const service = makeService();
+    // This is the exact case that caused InvalidProof(): exit_epoch=443824, deadline=443778
+    const result = await callProcessValidator(service, 443824);
+    expect(result).toBeNull();
+  });
+
+  it('increments exit_initiated skip counter when exitEpoch is set but >= deadline', async () => {
+    const prometheus = makePrometheusMock();
+    const service = makeService();
+    service.prometheus = prometheus;
+
+    await callProcessValidator(service, 443824);
+
+    expect(prometheus.validatorsSkippedCount.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'exit_initiated' }),
+    );
+  });
+
+  it('does NOT increment exit_initiated counter when exitEpoch < deadline (uses already_exited reason)', async () => {
+    const prometheus = makePrometheusMock();
+    const service = makeService();
+    service.prometheus = prometheus;
+
+    await callProcessValidator(service, DEADLINE_EPOCH - 1);
+
+    expect(prometheus.validatorsSkippedCount.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'already_exited' }),
+    );
+    expect(prometheus.validatorsSkippedCount.inc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'exit_initiated' }),
+    );
+  });
+
+  it('proceeds past the exit epoch checks when exitEpoch is Infinity (FAR_FUTURE_EPOCH)', async () => {
+    const service = makeService();
+    // proofSlotTimestamp is set so that the validator is not yet eligible,
+    // triggering the 'not_eligible_yet' early return — confirms the exit epoch
+    // checks were both passed (the method went further into the function).
+    const tooEarlyTimestamp = 0;
+    const result = await (service as any).processValidator(
+      makeValidatorInput(),
+      ACTIVATION_EPOCH,
+      DEADLINE_EPOCH,
+      makeStateView(Infinity),
+      tooEarlyTimestamp,
+      DELIVERED_TIMESTAMP,
+      0,
+      100,
+    );
+    expect(result).toBeNull(); // skipped for not_eligible_yet, not exit epoch reasons
+    expect(service.prometheus.validatorsSkippedCount.inc).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'not_eligible_yet' }),
+    );
+    expect(service.prometheus.validatorsSkippedCount.inc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'exit_initiated' }),
+    );
+    expect(service.prometheus.validatorsSkippedCount.inc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'already_exited' }),
+    );
+  });
+});

--- a/src/common/prover/prover.service.ts
+++ b/src/common/prover/prover.service.ts
@@ -355,6 +355,27 @@ export class ProverService implements OnModuleInit {
       return null;
     }
 
+    // The contract hardcodes FAR_FUTURE_EPOCH when reconstructing the validator leaf for proof
+    // verification, so a validator with exitEpoch already set (voluntary exit initiated but not
+    // yet past the deadline) would always produce InvalidProof(). Skip such validators.
+    if (deadlineStateValidator.exitEpoch !== Infinity) {
+      this.prometheus.validatorsSkippedCount.inc({
+        module_id: moduleId,
+        reason: 'exit_initiated',
+      });
+      this.prometheus.exitInitiatedCount.inc({ module_id: moduleId });
+
+      this.loggerService.log(
+        `[Blocks ${fromBlock}-${toBlock}] Validator skipped - exit already initiated:` +
+          `\n  Index: ${validatorIndex}` +
+          `\n  Public key: ${validator.validatorPubkey}` +
+          `\n  Exit epoch: ${deadlineStateValidator.exitEpoch}`,
+      );
+
+      stopValidatorTimer();
+      return null;
+    }
+
     const eligibleExitRequestTimestamp = this.getEligibleExitRequestTimestamp(deliveredTimestamp, activationEpoch);
     if (proofSlotTimestamp < eligibleExitRequestTimestamp) {
       this.prometheus.exitDeadlineFutureCount.inc({

--- a/src/common/providers/execution/patched-fallback-provider.spec.ts
+++ b/src/common/providers/execution/patched-fallback-provider.spec.ts
@@ -1,0 +1,152 @@
+import { NonEmptyArray } from '@lido-nestjs/execution';
+
+import { PatchedFallbackProvider } from './patched-fallback-provider';
+
+const mockLogger = {
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+const network = { chainId: 1, name: 'mainnet' };
+
+// maxRetries:1 so each provider is tried once with no backoff sleep
+const makeProvider = (urls: NonEmptyArray<string> = ['http://localhost:9999']) =>
+  new PatchedFallbackProvider({ urls, network, maxRetries: 1, minBackoffMs: 0 }, mockLogger);
+
+// Initialize fallback provider network so the internal `isValid` check passes
+const initNetworks = (provider: PatchedFallbackProvider) => {
+  (provider as any).fallbackProviders.forEach((fp: any) => {
+    fp.network = network;
+  });
+};
+
+const fetchErrorCallException = () =>
+  Object.assign(new Error('missing revert data in call exception'), {
+    code: 'CALL_EXCEPTION',
+    data: '0x',
+    error: { name: 'FetchError', code: 19, message: 'Temporary internal error. Please retry.' },
+  });
+
+const realContractRevert = () =>
+  Object.assign(new Error('execution reverted'), {
+    code: 'CALL_EXCEPTION',
+    data: '0x08c379a0',
+    reason: 'execution reverted',
+  });
+
+// ─── isNonRetryableError unit tests ──────────────────────────────────────────
+
+describe('PatchedFallbackProvider.isNonRetryableError', () => {
+  let provider: PatchedFallbackProvider;
+
+  beforeEach(() => {
+    provider = makeProvider();
+  });
+
+  describe('CALL_EXCEPTION wrapping a FetchError (transient RPC failure)', () => {
+    it('returns false so the fallback switches to the next provider', () => {
+      expect(provider.isNonRetryableError(fetchErrorCallException())).toBe(false);
+    });
+
+    it('returns false regardless of the FetchError message content', () => {
+      const error = Object.assign(new Error('call exception'), {
+        code: 'CALL_EXCEPTION',
+        error: { name: 'FetchError', code: 503 },
+      });
+      expect(provider.isNonRetryableError(error)).toBe(false);
+    });
+  });
+
+  describe('real CALL_EXCEPTION (contract revert — non-retryable)', () => {
+    it('returns true when there is no inner error', () => {
+      expect(provider.isNonRetryableError(realContractRevert())).toBe(true);
+    });
+
+    it('returns true when the inner error is not a FetchError', () => {
+      const error = Object.assign(new Error('execution reverted'), {
+        code: 'CALL_EXCEPTION',
+        error: { name: 'Error', message: 'execution reverted' },
+      });
+      expect(provider.isNonRetryableError(error)).toBe(true);
+    });
+  });
+
+  describe('other ethers error codes (delegated to base class)', () => {
+    it('returns true for INVALID_ARGUMENT', () => {
+      expect(provider.isNonRetryableError(Object.assign(new Error(), { code: 'INVALID_ARGUMENT' }))).toBe(true);
+    });
+
+    it('returns true for INSUFFICIENT_FUNDS', () => {
+      expect(provider.isNonRetryableError(Object.assign(new Error(), { code: 'INSUFFICIENT_FUNDS' }))).toBe(true);
+    });
+
+    it('returns true for UNPREDICTABLE_GAS_LIMIT', () => {
+      expect(provider.isNonRetryableError(Object.assign(new Error(), { code: 'UNPREDICTABLE_GAS_LIMIT' }))).toBe(true);
+    });
+
+    it('returns false for a plain network error without a code', () => {
+      expect(provider.isNonRetryableError(new Error('network error'))).toBe(false);
+    });
+
+    it('returns false for a server error (has serverError property)', () => {
+      const error = Object.assign(new Error('server error'), {
+        code: 'SERVER_ERROR',
+        serverError: new Error('upstream'),
+      });
+      expect(provider.isNonRetryableError(error)).toBe(false);
+    });
+  });
+});
+
+// ─── Full fallback integration tests ─────────────────────────────────────────
+
+describe('PatchedFallbackProvider fallback behavior (perform)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('routes to the second provider when the first returns CALL_EXCEPTION caused by FetchError', async () => {
+    const provider = makeProvider(['http://localhost:1', 'http://localhost:2']);
+    initNetworks(provider);
+
+    const [fp0, fp1] = (provider as any).fallbackProviders;
+    jest.spyOn(fp0.provider, 'perform').mockRejectedValue(fetchErrorCallException());
+    jest.spyOn(fp1.provider, 'perform').mockResolvedValue('0x1234');
+
+    const result = await provider.perform('eth_call', { to: '0xdead', data: '0x' });
+
+    expect(result).toBe('0x1234');
+    expect(fp0.provider.perform).toHaveBeenCalledTimes(1);
+    expect(fp1.provider.perform).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT route to the second provider for a real contract revert', async () => {
+    const provider = makeProvider(['http://localhost:1', 'http://localhost:2']);
+    initNetworks(provider);
+
+    const [fp0, fp1] = (provider as any).fallbackProviders;
+    jest.spyOn(fp0.provider, 'perform').mockRejectedValue(realContractRevert());
+    jest.spyOn(fp1.provider, 'perform').mockResolvedValue('0x1234');
+
+    await expect(provider.perform('eth_call', { to: '0xdead', data: '0x' })).rejects.toMatchObject({
+      code: 'CALL_EXCEPTION',
+    });
+    expect(fp0.provider.perform).toHaveBeenCalledTimes(1);
+    expect(fp1.provider.perform).not.toHaveBeenCalled();
+  });
+
+  it('throws AllProvidersFailedError when all providers return FetchError-wrapped CALL_EXCEPTION', async () => {
+    const provider = makeProvider(['http://localhost:1', 'http://localhost:2']);
+    initNetworks(provider);
+
+    const [fp0, fp1] = (provider as any).fallbackProviders;
+    jest.spyOn(fp0.provider, 'perform').mockRejectedValue(fetchErrorCallException());
+    jest.spyOn(fp1.provider, 'perform').mockRejectedValue(fetchErrorCallException());
+
+    await expect(provider.perform('eth_call', { to: '0xdead', data: '0x' })).rejects.toMatchObject({
+      message: expect.stringContaining('All attempts'),
+    });
+    expect(fp0.provider.perform).toHaveBeenCalledTimes(1);
+    expect(fp1.provider.perform).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/common/providers/execution/patched-fallback-provider.ts
+++ b/src/common/providers/execution/patched-fallback-provider.ts
@@ -1,0 +1,19 @@
+import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
+
+/**
+ * Extends SimpleFallbackJsonRpcBatchProvider to treat CALL_EXCEPTION errors caused by
+ * transient RPC transport failures (FetchError) as retryable.
+ *
+ * Upstream issue: ethers v5 wraps RPC transport errors (e.g. "Temporary internal error") as
+ * CALL_EXCEPTION. The base provider's nonRetryableErrors list includes CALL_EXCEPTION, so it
+ * stops retrying and never switches to the next fallback provider, even though the failure was
+ * a transient network issue rather than a real contract revert.
+ */
+export class PatchedFallbackProvider extends SimpleFallbackJsonRpcBatchProvider {
+  isNonRetryableError(error: any): boolean {
+    if (error?.code === 'CALL_EXCEPTION' && error?.error?.name === 'FetchError') {
+      return false;
+    }
+    return super.isNonRetryableError(error);
+  }
+}

--- a/src/common/providers/providers.module.ts
+++ b/src/common/providers/providers.module.ts
@@ -1,50 +1,60 @@
-import { FallbackProviderModule, NonEmptyArray } from '@lido-nestjs/execution';
+import { FallbackProviderModule, NonEmptyArray, SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { Module } from '@nestjs/common';
 import { ConditionalModule } from '@nestjs/config';
 
-import { Consensus } from './consensus/consensus';
-import { Execution } from './execution/execution';
 import { ConfigService } from '../config/config.service';
 import { WorkingMode } from '../config/env.validation';
 import { PrometheusService, RequestStatus } from '../prometheus';
+import { Consensus } from './consensus/consensus';
+import { Execution } from './execution/execution';
+import { PatchedFallbackProvider } from './execution/patched-fallback-provider';
+
+const buildProviderOptions = async (configService: ConfigService, prometheusService: PrometheusService) => ({
+  urls: configService.get('EL_RPC_URLS') as NonEmptyArray<string>,
+  network: configService.get('CHAIN_ID'),
+  fetchMiddlewares: [
+    async (next: any, ctx: any) => {
+      const targetName = new URL(ctx.provider.connection.url).hostname;
+      const reqName = 'batch';
+      const stop = prometheusService.outgoingELRequestsDuration.startTimer({
+        name: reqName,
+        target: targetName,
+      });
+      return await next()
+        .then((r: any) => {
+          prometheusService.outgoingELRequestsCount.inc({
+            name: reqName,
+            target: targetName,
+            status: RequestStatus.COMPLETE,
+          });
+          return r;
+        })
+        .catch((e: any) => {
+          prometheusService.outgoingELRequestsCount.inc({
+            name: reqName,
+            target: targetName,
+            status: RequestStatus.ERROR,
+          });
+          throw e;
+        })
+        .finally(() => stop());
+    },
+  ],
+});
 
 const ExecutionDaemon = () =>
   FallbackProviderModule.forRootAsync({
-    async useFactory(configService: ConfigService, prometheusService: PrometheusService) {
-      return {
-        urls: configService.get('EL_RPC_URLS') as NonEmptyArray<string>,
-        network: configService.get('CHAIN_ID'),
-        fetchMiddlewares: [
-          async (next, ctx) => {
-            const targetName = new URL(ctx.provider.connection.url).hostname;
-            const reqName = 'batch';
-            const stop = prometheusService.outgoingELRequestsDuration.startTimer({
-              name: reqName,
-              target: targetName,
-            });
-            return await next()
-              .then((r: any) => {
-                prometheusService.outgoingELRequestsCount.inc({
-                  name: reqName,
-                  target: targetName,
-                  status: RequestStatus.COMPLETE,
-                });
-                return r;
-              })
-              .catch((e: any) => {
-                prometheusService.outgoingELRequestsCount.inc({
-                  name: reqName,
-                  target: targetName,
-                  status: RequestStatus.ERROR,
-                });
-                throw e;
-              })
-              .finally(() => stop());
-          },
-        ],
-      };
-    },
+    useFactory: buildProviderOptions,
     inject: [ConfigService, PrometheusService],
+    providers: [
+      {
+        provide: SimpleFallbackJsonRpcBatchProvider,
+        useFactory: async (logger: any, configService: ConfigService, prometheusService: PrometheusService) =>
+          new PatchedFallbackProvider(await buildProviderOptions(configService, prometheusService), logger),
+        inject: [LOGGER_PROVIDER, ConfigService, PrometheusService],
+      },
+    ],
   });
 
 @Module({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
+    "types": ["jest"],
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
                                                                                                                         
 # Summary
                                                                                                                                    
  This PR fixes two independent bugs that together caused the bot to fail silently or crash when processing validator exit delay proofs.                                                                                                                           
                                                                                                                                                      
 ## Bug 1: InvalidProof() on validators with a pending CL exit
                                                                                                                                    
 ### Root cause
                                                                                                                                    
  The on-chain ValidatorExitDelayVerifier contract reconstructs the SSZ validator leaf for proof verification with exitEpoch hardcoded to FAR_FUTURE_EPOCH. This means the proof is only valid for validators that have not initiated a voluntary exit on the consensus layer at the time of the proof slot.                                                                                    
                           
  A validator in the active_exiting state (exit initiated, exit_epoch set to a finite value, but not yet past the withdrawal        
  deadline) will have a different SSZ leaf hash than what the contract expects → InvalidProof() (0x09bde339).
                                                                                                                                    
 ### Concrete incident        

  Validator `1039010` had exit_epoch: `443824` at proof slot `14200917` (deadline epoch `443778`). The exit was initiated after the deadline — the validator was eligible for penalisation — but the contract could not verify it. The bot retried indefinitely.
                                                                                                                                    
 ### Fix                      

  After the existing exitEpoch < exitDeadlineEpoch check (validator already exited cleanly before the deadline), add a second guard:
  
  `if (deadlineStateValidator.exitEpoch !== Infinity) → skip with reason 'exit_initiated'`                                
                                                                                                                                    
  Any validator with a finite exitEpoch at the deadline state — whether the exit was initiated before or after the deadline — cannot be proven via this contract mechanism and must be skipped.                                                                       
                                                                                                                                    
 ### Monitoring               

  Added a dedicated exit_initiated_count prometheus counter (label: module_id) so operators can track how many validators are being skipped for this reason independently of the generic validators_skipped_count breakdown.
                                                                                                                                    
  ---                      
  ## Bug 2: FetchError-wrapped CALL_EXCEPTION blocks fallback provider rotation
                                                                                                                                    
  ### Root cause
                                                                                                                                    
  Some RPC nodes return transient transport errors ("Temporary internal error. Please retry.") that ethers v5 wraps as a CALL_EXCEPTION. The base SimpleFallbackJsonRpcBatchProvider treats CALL_EXCEPTION as non-retryable, so it stops immediately without trying the next provider — even though the failure was a network hiccup, not a contract revert.                           
                           
  ### Fix                                                                                                                               
  
  PatchedFallbackProvider extends the base class and overrides isNonRetryableError:                                                 
  ```                         
  if (error?.code === 'CALL_EXCEPTION' && error?.error?.name === 'FetchError') {                                                    
    return false;  // retryable — let the fallback rotate to the next provider                                                      
  }                                                                                                                                 
  return super.isNonRetryableError(error);                                                                                          
  ```                                                                                                                                  
  Real contract reverts (CALL_EXCEPTION without an inner FetchError) are still treated as non-retryable, preserving correct behaviour.                                                                                                                        
                                                                                                                                    
  ---                                                                                                                               
  Tests
                                                                                                                                    
  - `prover.service.spec.ts` — 6 unit tests for processValidator exit epoch filtering: verifies that exitEpoch < deadline, exitEpoch == deadline, and exitEpoch > deadline (finite) all skip, that the correct prometheus counters are incremented, and that exitEpoch === Infinity (FAR_FUTURE_EPOCH) correctly passes through to the next check.
  - `patched-fallback-provider.spec.ts` — unit tests for isNonRetryableError classification and integration tests for the full fallback rotation: FetchError-wrapped exceptions route to the next provider, real reverts do not, and exhausted providers throw AllProvidersFailedError.