### PR TITLE
fix: decode submitReport format 2

### DIFF
--- a/src/common/prover/prover.service.spec.ts
+++ b/src/common/prover/prover.service.spec.ts
@@ -166,3 +166,92 @@ describe('ProverService.processValidator - exit epoch filtering', () => {
     );
   });
 });
+
+// ─── decodeValidatorsData ─────────────────────────────────────────────────────
+
+describe('ProverService.decodeValidatorsData', () => {
+  const decode = (hex: string, dataFormat: number) => (makeService() as any).decodeValidatorsData(hex, dataFormat);
+
+  // Real tx 0xaa8dad0ec045cf251ed2c530e25c139dd71bd6dea35a99230715a40ae613b822
+  // submitReportData on Hoodi (chain 559024), block 2894999
+  // dataFormat=2 (DATA_FORMAT_LIST_WITH_KEY_INDEX), requestsCount=1
+  const REAL_TX_DATA_FORMAT_2 =
+    '0x' +
+    '000001' + // moduleId = 1  (3 bytes)
+    '0000000007' + // nodeOpId = 7  (5 bytes)
+    '0000000000103f8e' + // validatorIndex = 1064846  (8 bytes)
+    '0000000000000009' + // keyIndex = 9  (8 bytes)  ← format-2 extra field
+    'ae2fd379751dc0256d7ea54eca4d14f8456aec60bcd55397f17f2f01fee04381f5ee7c388ef1bcf0a53f9c5520798eba'; // pubkey (48 bytes)
+
+  it('format 2: correctly decodes the 72-byte real-world entry (regression for BigInt crash)', () => {
+    const entries = decode(REAL_TX_DATA_FORMAT_2, 2);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      exitDataIndex: 0,
+      moduleId: BigInt(1),
+      nodeOpId: BigInt(7),
+      validatorIndex: BigInt(1064846),
+      validatorPubkey:
+        '0xae2fd379751dc0256d7ea54eca4d14f8456aec60bcd55397f17f2f01fee04381f5ee7c388ef1bcf0a53f9c5520798eba',
+    });
+  });
+
+  it('format 2: old ENTRY_SIZE=64 code would have thrown "Cannot convert 0x to a BigInt"', () => {
+    // Manually reproduce the old broken behaviour so the regression is documented
+    const hex = REAL_TX_DATA_FORMAT_2.slice(2); // strip 0x
+    const data = Buffer.from(hex, 'hex');
+    expect(data.byteLength).toBe(72);
+
+    const ENTRY_SIZE_OLD = 64;
+    const entries = [];
+    for (let offset = 0; offset < data.byteLength; offset += ENTRY_SIZE_OLD) {
+      const entry = data.subarray(offset, offset + ENTRY_SIZE_OLD);
+      if (offset > 0) {
+        // second iteration: entry is 8 bytes, subarray(8,16) is empty → BigInt crash
+        expect(entry.subarray(8, 16).toString('hex')).toBe('');
+        expect(() => BigInt('0x' + entry.subarray(8, 16).toString('hex'))).toThrow(SyntaxError);
+        break;
+      }
+      entries.push(entry);
+    }
+  });
+
+  it('format 2: correctly assigns exitDataIndex when multiple 72-byte entries are present', () => {
+    // Two identical entries back-to-back
+    const single = REAL_TX_DATA_FORMAT_2.slice(2); // strip 0x
+    const twoEntries = '0x' + single + single;
+
+    const entries = decode(twoEntries, 2);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].exitDataIndex).toBe(0);
+    expect(entries[1].exitDataIndex).toBe(1);
+    expect(entries[1].moduleId).toBe(BigInt(1));
+  });
+
+  it('format 1: correctly decodes a 64-byte entry (existing behaviour unchanged)', () => {
+    // Build a format-1 entry (no keyIndex field)
+    const moduleId = '000001'; // 3 bytes
+    const nodeOpId = '0000000007'; // 5 bytes
+    const validatorIndex = '0000000000103f8e'; // 8 bytes
+    const pubkey = 'ab'.repeat(48); // 48 bytes
+    const hex = '0x' + moduleId + nodeOpId + validatorIndex + pubkey;
+
+    const entries = decode(hex, 1);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].moduleId).toBe(BigInt(1));
+    expect(entries[0].nodeOpId).toBe(BigInt(7));
+    expect(entries[0].validatorIndex).toBe(BigInt(1064846));
+    expect(entries[0].validatorPubkey).toBe('0x' + pubkey);
+  });
+
+  it('throws for unsupported data formats', () => {
+    expect(() => decode('0x', 3)).toThrow('Unsupported data format: 3');
+    expect(() => decode('0x', 0)).toThrow('Unsupported data format: 0');
+  });
+
+  it('returns empty array for empty data in any supported format', () => {
+    expect(decode('0x', 1)).toEqual([]);
+    expect(decode('0x', 2)).toEqual([]);
+  });
+});

--- a/src/common/prover/prover.service.ts
+++ b/src/common/prover/prover.service.ts
@@ -638,7 +638,10 @@ export class ProverService implements OnModuleInit {
         `\n  Data Format: ${exitRequest.exitRequestsData.dataFormat}`,
     );
 
-    const validators = this.decodeValidatorsData(exitRequest.exitRequestsData.data);
+    const validators = this.decodeValidatorsData(
+      exitRequest.exitRequestsData.data,
+      exitRequest.exitRequestsData.dataFormat,
+    );
     const deliveredTimestamp = await this.exitRequests.getExitRequestDeliveryTimestamp(exitRequest.exitRequestsHash);
 
     this.loggerService.log(
@@ -1291,13 +1294,21 @@ export class ProverService implements OnModuleInit {
     return validatorsByDeadlineSlot;
   }
 
-  private decodeValidatorsData(encodedHex: string): {
+  private decodeValidatorsData(
+    encodedHex: string,
+    dataFormat: number = 1,
+  ): {
     exitDataIndex: number;
     moduleId: bigint;
     nodeOpId: bigint;
     validatorIndex: bigint;
     validatorPubkey: string;
   }[] {
+    // DATA_FORMAT_LIST (1):          64 bytes/entry: moduleId(3) + nodeOpId(5) + validatorIndex(8) + pubkey(48)
+    // DATA_FORMAT_LIST_WITH_KEY_INDEX (2): 72 bytes/entry: moduleId(3) + nodeOpId(5) + validatorIndex(8) + keyIndex(8) + pubkey(48)
+    const DATA_FORMAT_LIST = 1;
+    const DATA_FORMAT_LIST_WITH_KEY_INDEX = 2;
+
     // Remove '0x' prefix if present
     if (encodedHex.startsWith('0x')) {
       encodedHex = encodedHex.slice(2);
@@ -1305,7 +1316,19 @@ export class ProverService implements OnModuleInit {
 
     const data = Buffer.from(encodedHex, 'hex');
 
-    const ENTRY_SIZE = 64;
+    let ENTRY_SIZE: number;
+    let PUBKEY_OFFSET: number;
+
+    if (dataFormat === DATA_FORMAT_LIST_WITH_KEY_INDEX) {
+      ENTRY_SIZE = 72;
+      PUBKEY_OFFSET = 24; // moduleId(3) + nodeOpId(5) + validatorIndex(8) + keyIndex(8) = 24
+    } else if (dataFormat === DATA_FORMAT_LIST) {
+      ENTRY_SIZE = 64;
+      PUBKEY_OFFSET = 16; // moduleId(3) + nodeOpId(5) + validatorIndex(8) = 16
+    } else {
+      throw new Error(`Unsupported data format: ${dataFormat}`);
+    }
+
     const entries: {
       exitDataIndex: number;
       moduleId: bigint;
@@ -1321,7 +1344,7 @@ export class ProverService implements OnModuleInit {
       const moduleId = BigInt('0x' + entry.subarray(0, 3).toString('hex'));
       const nodeOpId = BigInt('0x' + entry.subarray(3, 8).toString('hex'));
       const validatorIndex = BigInt('0x' + entry.subarray(8, 16).toString('hex'));
-      const validatorPubkey = '0x' + entry.subarray(16, 64).toString('hex');
+      const validatorPubkey = '0x' + entry.subarray(PUBKEY_OFFSET, PUBKEY_OFFSET + 48).toString('hex');
 
       entries.push({
         exitDataIndex,


### PR DESCRIPTION
## fix: support `DATA_FORMAT_LIST_WITH_KEY_INDEX` (format 2) in `decodeValidatorsData`

### Problem

The daemon crashed with an unhandled `SyntaxError: Cannot convert 0x to a BigInt` whenever it processed a `submitReportData` transaction that used `dataFormat = 2` (`DATA_FORMAT_LIST_WITH_KEY_INDEX`).

**Root cause.** `decodeValidatorsData` hard-coded `ENTRY_SIZE = 64`, which matches format 1 only:

```
Format 1 — DATA_FORMAT_LIST (64 bytes/entry):
  | moduleId(3) | nodeOpId(5) | validatorIndex(8) | validatorPubkey(48) |

Format 2 — DATA_FORMAT_LIST_WITH_KEY_INDEX (72 bytes/entry):
  | moduleId(3) | nodeOpId(5) | validatorIndex(8) | keyIndex(8) | validatorPubkey(48) |
```

A format-2 report with 1 validator produces **72 bytes** of calldata. With `ENTRY_SIZE = 64` the loop made two iterations: the first consumed bytes 0–63 (correct), and the second took the remaining 8 bytes (offset 64–71). On that second pass `entry.subarray(8, 16)` returned an **empty buffer**, so `BigInt('0x' + '')` → `BigInt('0x')` → `SyntaxError`.

### Fix

`decodeValidatorsData` now accepts a `dataFormat` argument (defaults to `1` for backward compatibility) and selects the correct geometry:

| Format | `ENTRY_SIZE` | `PUBKEY_OFFSET` |
|--------|-------------|-----------------|
| 1 (`DATA_FORMAT_LIST`) | 64 | 16 |
| 2 (`DATA_FORMAT_LIST_WITH_KEY_INDEX`) | 72 | 24 |
| other | — | throws `Unsupported data format: N` |

The pubkey offset is shifted by 8 bytes in format 2 to skip `keyIndex`. The `keyIndex` field itself is not surfaced in the return value — the downstream proof logic does not need it.
