### PR TITLE
feat: Support Gloas

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start:prod": "NODE_OPTIONS='--max-old-space-size=8192 --experimental-vm-modules' node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test-daemon": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --config test/jest-daemon-e2e.json",
     "estimate-gas": "ts-node scripts/estimate-gas-cost.ts"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test-daemon": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --config test/jest-daemon-e2e.json",
-    "estimate-gas": "ts-node scripts/estimate-gas-cost.ts"
+    "estimate-gas": "ts-node scripts/estimate-gas-cost.ts",
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "yarn lint"
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "0.8.0",
@@ -80,6 +84,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
+    "simple-git-hooks": "^2.13.1",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",

--- a/src/common/providers/consensus/consensus.spec.ts
+++ b/src/common/providers/consensus/consensus.spec.ts
@@ -1,0 +1,192 @@
+import { Consensus, SupportedFork } from './consensus';
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const makeLogger = () => ({ log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() });
+
+const makeConfigService = () => ({
+  get: jest.fn((key: string) => {
+    const cfg: Record<string, any> = {
+      CL_API_URLS: ['http://cl:5052'],
+      CL_API_RESPONSE_TIMEOUT_MS: 10_000,
+      CL_API_MAX_RETRIES: 1,
+      CL_API_RETRY_DELAY_MS: 0,
+      FORK_NAME: 'fulu',
+    };
+    return cfg[key];
+  }),
+});
+
+/** Minimal BeaconConfig returned by /eth/v1/config/spec */
+const BEACON_CONFIG = {
+  SLOTS_PER_EPOCH: '32',
+  SECONDS_PER_SLOT: '12',
+  CAPELLA_FORK_EPOCH: '194048',
+  ETH1_FOLLOW_DISTANCE: '2048',
+  EPOCHS_PER_ETH1_VOTING_PERIOD: '64',
+  SLOTS_PER_HISTORICAL_ROOT: '8192',
+  MIN_VALIDATOR_WITHDRAWABILITY_DELAY: '256',
+};
+
+/** Genesis response */
+const GENESIS = {
+  genesis_time: '1606824023',
+  genesis_validators_root: '0x' + '00'.repeat(32),
+  genesis_fork_version: '0x00000000',
+};
+
+/**
+ * Create a minimal Consensus instance and stub out onModuleInit network calls
+ * so SSZ is loaded without making real HTTP requests.
+ */
+async function makeInitialisedConsensus() {
+  const consensus = new (Consensus as any)(makeLogger(), undefined, makeConfigService()) as InstanceType<
+    typeof Consensus
+  > & { [k: string]: any };
+
+  jest.spyOn(consensus, 'getGenesis').mockResolvedValue(GENESIS as any);
+  jest.spyOn(consensus, 'getConfig').mockResolvedValue(BEACON_CONFIG as any);
+
+  await consensus.onModuleInit();
+  return consensus;
+}
+
+// ─── SupportedFork ────────────────────────────────────────────────────────────
+
+describe('SupportedFork enum', () => {
+  it('includes gloas', () => {
+    expect(SupportedFork.gloas).toBe('gloas');
+  });
+
+  it('includes all pre-GLOAS forks', () => {
+    expect(SupportedFork.capella).toBe('capella');
+    expect(SupportedFork.deneb).toBe('deneb');
+    expect(SupportedFork.electra).toBe('electra');
+    expect(SupportedFork.fulu).toBe('fulu');
+  });
+});
+
+// ─── getBlockInfo ─────────────────────────────────────────────────────────────
+
+describe('Consensus.getBlockInfo', () => {
+  let consensus: Awaited<ReturnType<typeof makeInitialisedConsensus>>;
+
+  beforeAll(async () => {
+    consensus = await makeInitialisedConsensus();
+  });
+
+  const stubBlockRequest = (forkName: string, blockJson: object) => {
+    jest.spyOn(consensus, 'retryRequest').mockResolvedValue({
+      body: { json: jest.fn().mockResolvedValue({ data: { message: blockJson } }) } as any,
+      headers: { 'eth-consensus-version': forkName } as any,
+    });
+  };
+
+  it('returns { block, forkName } for each supported fork', async () => {
+    const testSsz = await eval(`import('@lodestar/types').then((m) => m.ssz)`);
+    for (const fork of [SupportedFork.fulu, SupportedFork.gloas]) {
+      // Use fulu minimal block JSON (gloas SSZ types = fulu in lodestar 1.34.x)
+      const fuluBlock = testSsz.fulu.BeaconBlock.toJson(testSsz.fulu.BeaconBlock.defaultValue());
+      stubBlockRequest(fork, fuluBlock as object);
+
+      const result = await consensus.getBlockInfo('head');
+      expect(result).toHaveProperty('block');
+      expect(result).toHaveProperty('forkName', fork);
+    }
+  });
+
+  it('throws when the fork name returned by the CL client is unsupported', async () => {
+    jest.spyOn(consensus, 'retryRequest').mockResolvedValue({
+      body: { json: jest.fn().mockResolvedValue({ data: { message: {} } }) } as any,
+      headers: { 'eth-consensus-version': 'unknown_fork_xyz' } as any,
+    });
+
+    await expect(consensus.getBlockInfo('head')).rejects.toThrow('Fork name [unknown_fork_xyz] is not supported');
+  });
+});
+
+// ─── getStateElBlockInfo ──────────────────────────────────────────────────────
+
+describe('Consensus.getStateElBlockInfo', () => {
+  let consensus: Awaited<ReturnType<typeof makeInitialisedConsensus>>;
+  let ssz: Awaited<ReturnType<typeof import('@lodestar/types').then>>;
+
+  beforeAll(async () => {
+    consensus = await makeInitialisedConsensus();
+    // eval() bypasses Jest's CommonJS resolver for this ESM-only package,
+    // matching how consensus.ts itself loads the library in onModuleInit.
+    ssz = await eval(`import('@lodestar/types').then((m) => m.ssz)`);
+  });
+
+  const makeStateBytes = (forkName: keyof typeof ssz, blockHash: Uint8Array, blockNumber: number): Uint8Array => {
+    const defaultState = (ssz[forkName] as any).BeaconState.defaultValue();
+    defaultState.latestExecutionPayloadHeader.blockHash = blockHash;
+    defaultState.latestExecutionPayloadHeader.blockNumber = blockNumber;
+    return (ssz[forkName] as any).BeaconState.serialize(defaultState);
+  };
+
+  it('returns blockHash as a 0x-prefixed hex string', async () => {
+    const expectedHash = new Uint8Array(32).fill(0xab);
+    const stateBytes = makeStateBytes('fulu', expectedHash, 42);
+
+    jest.spyOn(consensus, 'getState').mockResolvedValue({ bodyBytes: stateBytes, forkName: SupportedFork.fulu });
+
+    const result = await consensus.getStateElBlockInfo('finalized');
+
+    expect(result.blockHash).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(result.blockHash).toBe('0x' + Buffer.from(expectedHash).toString('hex'));
+  });
+
+  it('returns blockNumber as a number', async () => {
+    const stateBytes = makeStateBytes('fulu', new Uint8Array(32), 21_500_000);
+
+    jest.spyOn(consensus, 'getState').mockResolvedValue({ bodyBytes: stateBytes, forkName: SupportedFork.fulu });
+
+    const result = await consensus.getStateElBlockInfo('finalized');
+
+    expect(result.blockNumber).toBe(21_500_000);
+  });
+
+  it('reads from latestExecutionPayloadHeader (not executionPayload in block body)', async () => {
+    const KNOWN_HASH = new Uint8Array(32).fill(0xcc);
+    const KNOWN_NUMBER = 99_999_999;
+    const stateBytes = makeStateBytes('fulu', KNOWN_HASH, KNOWN_NUMBER);
+
+    jest.spyOn(consensus, 'getState').mockResolvedValue({ bodyBytes: stateBytes, forkName: SupportedFork.fulu });
+
+    const result = await consensus.getStateElBlockInfo('0xsome_state_root');
+
+    expect(result.blockHash).toBe('0x' + Buffer.from(KNOWN_HASH).toString('hex'));
+    expect(result.blockNumber).toBe(KNOWN_NUMBER);
+  });
+
+  it('passes the stateId through to getState', async () => {
+    const stateBytes = makeStateBytes('fulu', new Uint8Array(32), 0);
+    const getStateSpy = jest.spyOn(consensus, 'getState').mockResolvedValue({
+      bodyBytes: stateBytes,
+      forkName: SupportedFork.fulu,
+    });
+
+    await consensus.getStateElBlockInfo('0xmy_custom_state_root');
+
+    expect(getStateSpy).toHaveBeenCalledWith('0xmy_custom_state_root');
+  });
+
+  it('propagates errors from getState', async () => {
+    jest.spyOn(consensus, 'getState').mockRejectedValue(new Error('state fetch failed'));
+
+    await expect(consensus.getStateElBlockInfo('finalized')).rejects.toThrow('state fetch failed');
+  });
+
+  it('works with the gloas fork name (same SSZ structure as fulu in lodestar 1.34.x)', async () => {
+    const KNOWN_HASH = new Uint8Array(32).fill(0xde);
+    const stateBytes = makeStateBytes('gloas', KNOWN_HASH, 777);
+
+    jest.spyOn(consensus, 'getState').mockResolvedValue({ bodyBytes: stateBytes, forkName: SupportedFork.gloas });
+
+    const result = await consensus.getStateElBlockInfo('head');
+
+    expect(result.blockHash).toBe('0x' + Buffer.from(KNOWN_HASH).toString('hex'));
+    expect(result.blockNumber).toBe(777);
+  });
+});

--- a/src/common/providers/consensus/consensus.ts
+++ b/src/common/providers/consensus/consensus.ts
@@ -117,14 +117,6 @@ export class Consensus extends BaseRestProvider implements OnModuleInit {
     return { block, forkName: forkName as SupportedFork };
   }
 
-  /**
-   * Returns EL block hash and number anchored to the given beacon state.
-   *
-   * Post-ePBS (GLOAS): execution_payload is absent from BeaconBlockBody.
-   * The state's latestExecutionPayloadHeader holds the last revealed EL block (slot N-1),
-   * which guarantees deposit symmetry. We read blockHash and blockNumber from there
-   * instead of from the block body.
-   */
   public async getStateElBlockInfo(stateId: StateId): Promise<BlockElInfo> {
     const state = await this.getState(stateId);
     const stateView = ssz[state.forkName].BeaconState.deserializeToView(state.bodyBytes);

--- a/src/common/providers/consensus/consensus.ts
+++ b/src/common/providers/consensus/consensus.ts
@@ -13,18 +13,25 @@ import { RequestOptions } from '../base/utils/func';
 
 let ssz: typeof sszType;
 
-enum SupportedFork {
+export enum SupportedFork {
   capella = 'capella',
   deneb = 'deneb',
   electra = 'electra',
   fulu = 'fulu',
+  gloas = 'gloas',
 }
 
 export type SupportedBlock =
   | ValueOfFields<typeof ssz.capella.BeaconBlock.fields>
   | ValueOfFields<typeof ssz.deneb.BeaconBlock.fields>
   | ValueOfFields<typeof ssz.electra.BeaconBlock.fields>
-  | ValueOfFields<typeof ssz.fulu.BeaconBlock.fields>;
+  | ValueOfFields<typeof ssz.fulu.BeaconBlock.fields>
+  | ValueOfFields<typeof ssz.gloas.BeaconBlock.fields>;
+
+export interface BlockElInfo {
+  blockHash: string;
+  blockNumber: number;
+}
 
 export interface State {
   bodyBytes: Uint8Array;
@@ -97,7 +104,7 @@ export class Consensus extends BaseRestProvider implements OnModuleInit {
     return jsonBody.data;
   }
 
-  public async getBlockInfo(blockId: BlockId): Promise<SupportedBlock> {
+  public async getBlockInfo(blockId: BlockId): Promise<{ block: SupportedBlock; forkName: SupportedFork }> {
     const { body, headers } = await this.retryRequest((baseUrl) =>
       this.baseGet(baseUrl, this.endpoints.blockInfo(blockId)),
     );
@@ -106,7 +113,27 @@ export class Consensus extends BaseRestProvider implements OnModuleInit {
       throw new Error(`Fork name [${forkName}] is not supported`);
     }
     const jsonBody = (await body.json()) as { data: { message: JSON } };
-    return ssz[forkName as SupportedFork].BeaconBlock.fromJson(jsonBody.data.message);
+    const block = ssz[forkName as SupportedFork].BeaconBlock.fromJson(jsonBody.data.message);
+    return { block, forkName: forkName as SupportedFork };
+  }
+
+  /**
+   * Returns EL block hash and number anchored to the given beacon state.
+   *
+   * Post-ePBS (GLOAS): execution_payload is absent from BeaconBlockBody.
+   * The state's latestExecutionPayloadHeader holds the last revealed EL block (slot N-1),
+   * which guarantees deposit symmetry. We read blockHash and blockNumber from there
+   * instead of from the block body.
+   */
+  public async getStateElBlockInfo(stateId: StateId): Promise<BlockElInfo> {
+    const state = await this.getState(stateId);
+    const stateView = ssz[state.forkName].BeaconState.deserializeToView(state.bodyBytes);
+    const header = stateView.latestExecutionPayloadHeader;
+    const blockHashHex = '0x' + Buffer.from(header.blockHash as Uint8Array).toString('hex');
+    return {
+      blockHash: blockHashHex,
+      blockNumber: header.blockNumber as number,
+    };
   }
 
   public async getBeaconHeader(blockId: BlockId): Promise<BlockHeaderResponse> {

--- a/src/daemon/services/roots-processor.spec.ts
+++ b/src/daemon/services/roots-processor.spec.ts
@@ -45,11 +45,7 @@ const makeBlockWithExecutionPayload = (blockHash: string) => ({
   },
 });
 
-const makeService = (
-  consensus = makeConsensusMock(),
-  provider = makeProviderMock(),
-  prometheus = makePrometheus(),
-) =>
+const makeService = (consensus = makeConsensusMock(), provider = makeProviderMock(), prometheus = makePrometheus()) =>
   new (RootsProcessor as any)(
     makeLogger(), // logger
     {}, // config
@@ -252,8 +248,14 @@ describe('RootsProcessor.processBlockRoot', () => {
     });
 
     const service = new (RootsProcessor as any)(
-      makeLogger(), {}, prometheus, consensus,
-      { get: jest.fn(), set: jest.fn() }, prover, provider, {},
+      makeLogger(),
+      {},
+      prometheus,
+      consensus,
+      { get: jest.fn(), set: jest.fn() },
+      prover,
+      provider,
+      {},
     ) as any;
 
     await service.processBlockRoot(prevHeader, finalizedHeader);

--- a/src/daemon/services/roots-processor.spec.ts
+++ b/src/daemon/services/roots-processor.spec.ts
@@ -1,0 +1,281 @@
+import { RootsProcessor } from './roots-processor';
+import { SupportedFork } from '../../common/providers/consensus/consensus';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const makeLogger = () => ({ log: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() });
+
+const makePrometheus = () => ({
+  blockRangeProcessingDuration: { startTimer: jest.fn(() => jest.fn()) },
+  blockRangeSize: { observe: jest.fn() },
+});
+
+const makeConsensusMock = (overrides: Partial<Record<string, jest.Mock>> = {}) => ({
+  getBlockInfo: jest.fn(),
+  getStateElBlockInfo: jest.fn(),
+  ...overrides,
+});
+
+const makeProviderMock = () => ({
+  getBlock: jest.fn(),
+});
+
+const makeHeader = (root: string, stateRoot: string, slot = '100') => ({
+  root,
+  canonical: true,
+  header: {
+    message: {
+      slot,
+      proposer_index: '1',
+      parent_root: '0xparent',
+      state_root: stateRoot,
+      body_root: '0xbody',
+    },
+    signature: '0xsig',
+  },
+});
+
+const makeBlockWithExecutionPayload = (blockHash: string) => ({
+  body: {
+    executionPayload: {
+      // hexlify expects Uint8Array; the real type is a Uint8Array, but for tests
+      // we use a Buffer which hexlify also accepts
+      blockHash: Buffer.from(blockHash.replace('0x', ''), 'hex'),
+    },
+  },
+});
+
+const makeService = (
+  consensus = makeConsensusMock(),
+  provider = makeProviderMock(),
+  prometheus = makePrometheus(),
+) =>
+  new (RootsProcessor as any)(
+    makeLogger(), // logger
+    {}, // config
+    prometheus, // prometheus
+    consensus, // consensus
+    { get: jest.fn(), set: jest.fn() }, // lastProcessedRoot
+    { handleBlock: jest.fn() }, // prover
+    provider, // provider
+    {}, // exitRequests
+  ) as InstanceType<typeof RootsProcessor> & { [k: string]: any };
+
+// ─── resolveElBlockInfo — pre-GLOAS path ─────────────────────────────────────
+
+describe('RootsProcessor.resolveElBlockInfo — pre-GLOAS', () => {
+  const BLOCK_HASH = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+  const BLOCK_NUMBER = 999_000;
+  const FORK_NAME = SupportedFork.fulu;
+
+  let service: ReturnType<typeof makeService>;
+  let consensus: ReturnType<typeof makeConsensusMock>;
+  let provider: ReturnType<typeof makeProviderMock>;
+  const header = makeHeader('0xroot', '0xstateroot');
+
+  beforeEach(() => {
+    consensus = makeConsensusMock();
+    provider = makeProviderMock();
+    service = makeService(consensus, provider);
+
+    consensus.getBlockInfo.mockResolvedValue({ block: makeBlockWithExecutionPayload(BLOCK_HASH), forkName: FORK_NAME });
+    provider.getBlock.mockResolvedValue({ number: BLOCK_NUMBER });
+  });
+
+  it('calls getBlockInfo with the CL root', async () => {
+    await service.resolveElBlockInfo(header);
+    expect(consensus.getBlockInfo).toHaveBeenCalledWith('0xroot');
+  });
+
+  it('returns block number from the EL provider', async () => {
+    const result = await service.resolveElBlockInfo(header);
+    expect(result.blockNumber).toBe(BLOCK_NUMBER);
+  });
+
+  it('returns hex-encoded block hash from executionPayload', async () => {
+    const result = await service.resolveElBlockInfo(header);
+    expect(result.blockHash).toBe(BLOCK_HASH);
+  });
+
+  it('fetches EL block using the hash from executionPayload', async () => {
+    await service.resolveElBlockInfo(header);
+    expect(provider.getBlock).toHaveBeenCalledWith(BLOCK_HASH);
+  });
+
+  it('does NOT call getStateElBlockInfo', async () => {
+    await service.resolveElBlockInfo(header);
+    expect(consensus.getStateElBlockInfo).not.toHaveBeenCalled();
+  });
+
+  it.each([SupportedFork.capella, SupportedFork.deneb, SupportedFork.electra, SupportedFork.fulu])(
+    'uses the executionPayload path for %s fork',
+    async (forkName) => {
+      consensus.getBlockInfo.mockResolvedValue({ block: makeBlockWithExecutionPayload(BLOCK_HASH), forkName });
+      await service.resolveElBlockInfo(header);
+      expect(consensus.getStateElBlockInfo).not.toHaveBeenCalled();
+      expect(provider.getBlock).toHaveBeenCalledWith(BLOCK_HASH);
+    },
+  );
+});
+
+// ─── resolveElBlockInfo — GLOAS path ─────────────────────────────────────────
+
+describe('RootsProcessor.resolveElBlockInfo — GLOAS (post-ePBS)', () => {
+  const STATE_ROOT = '0xstateroot1234';
+  const EL_BLOCK_HASH = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+  const EL_BLOCK_NUMBER = 21_500_000;
+
+  let service: ReturnType<typeof makeService>;
+  let consensus: ReturnType<typeof makeConsensusMock>;
+  let provider: ReturnType<typeof makeProviderMock>;
+  const header = makeHeader('0xcl_root', STATE_ROOT, '200');
+
+  beforeEach(() => {
+    consensus = makeConsensusMock();
+    provider = makeProviderMock();
+    service = makeService(consensus, provider);
+
+    consensus.getBlockInfo.mockResolvedValue({ block: {}, forkName: SupportedFork.gloas });
+    consensus.getStateElBlockInfo.mockResolvedValue({ blockHash: EL_BLOCK_HASH, blockNumber: EL_BLOCK_NUMBER });
+  });
+
+  it('calls getBlockInfo with the CL root', async () => {
+    await service.resolveElBlockInfo(header);
+    expect(consensus.getBlockInfo).toHaveBeenCalledWith('0xcl_root');
+  });
+
+  it('calls getStateElBlockInfo with the state_root from the header', async () => {
+    await service.resolveElBlockInfo(header);
+    expect(consensus.getStateElBlockInfo).toHaveBeenCalledWith(STATE_ROOT);
+  });
+
+  it('returns blockNumber from getStateElBlockInfo (no EL provider call)', async () => {
+    const result = await service.resolveElBlockInfo(header);
+    expect(result.blockNumber).toBe(EL_BLOCK_NUMBER);
+    expect(provider.getBlock).not.toHaveBeenCalled();
+  });
+
+  it('returns blockHash from getStateElBlockInfo', async () => {
+    const result = await service.resolveElBlockInfo(header);
+    expect(result.blockHash).toBe(EL_BLOCK_HASH);
+  });
+
+  it('does NOT access executionPayload from the block', async () => {
+    // block has no executionPayload — if the code touched it, it would throw
+    consensus.getBlockInfo.mockResolvedValue({
+      block: { body: {} }, // no executionPayload field
+      forkName: SupportedFork.gloas,
+    });
+    await expect(service.resolveElBlockInfo(header)).resolves.toBeDefined();
+  });
+});
+
+// ─── processBlockRoot ─────────────────────────────────────────────────────────
+
+describe('RootsProcessor.processBlockRoot', () => {
+  const PREV_BLOCK_NUMBER = 21_400_000;
+  const FINALIZED_BLOCK_NUMBER = 21_500_000;
+  const PREV_HASH = '0x' + 'aa'.repeat(32);
+  const FINAL_HASH = '0x' + 'bb'.repeat(32);
+
+  const prevHeader = makeHeader('0xprev_root', '0xprev_state', '1000');
+  const finalizedHeader = makeHeader('0xfinalized_root', '0xfinalized_state', '1032');
+
+  const setupService = (forkName: SupportedFork) => {
+    const consensus = makeConsensusMock();
+    const provider = makeProviderMock();
+    const prometheus = makePrometheus();
+    const prover = { handleBlock: jest.fn() };
+    const service = new (RootsProcessor as any)(
+      makeLogger(),
+      {},
+      prometheus,
+      consensus,
+      { get: jest.fn(), set: jest.fn() },
+      prover,
+      provider,
+      {},
+    ) as InstanceType<typeof RootsProcessor> & { [k: string]: any };
+
+    if (forkName === SupportedFork.gloas) {
+      consensus.getBlockInfo.mockResolvedValue({ block: {}, forkName: SupportedFork.gloas });
+      consensus.getStateElBlockInfo
+        .mockResolvedValueOnce({ blockHash: PREV_HASH, blockNumber: PREV_BLOCK_NUMBER })
+        .mockResolvedValueOnce({ blockHash: FINAL_HASH, blockNumber: FINALIZED_BLOCK_NUMBER });
+    } else {
+      consensus.getBlockInfo
+        .mockResolvedValueOnce({ block: makeBlockWithExecutionPayload(PREV_HASH), forkName })
+        .mockResolvedValueOnce({ block: makeBlockWithExecutionPayload(FINAL_HASH), forkName });
+      provider.getBlock
+        .mockResolvedValueOnce({ number: PREV_BLOCK_NUMBER })
+        .mockResolvedValueOnce({ number: FINALIZED_BLOCK_NUMBER });
+    }
+
+    return { service, consensus, provider, prover, prometheus };
+  };
+
+  it('calls prover.handleBlock with EL block numbers derived from prevHeader and finalizedHeader', async () => {
+    const { service, prover } = setupService(SupportedFork.fulu);
+    await service.processBlockRoot(prevHeader, finalizedHeader);
+    expect(prover.handleBlock).toHaveBeenCalledWith(PREV_BLOCK_NUMBER, FINALIZED_BLOCK_NUMBER);
+  });
+
+  it('uses GLOAS path for both headers when forkName is gloas', async () => {
+    const { service, consensus, provider } = setupService(SupportedFork.gloas);
+    await service.processBlockRoot(prevHeader, finalizedHeader);
+    expect(consensus.getStateElBlockInfo).toHaveBeenCalledWith('0xprev_state');
+    expect(consensus.getStateElBlockInfo).toHaveBeenCalledWith('0xfinalized_state');
+    expect(provider.getBlock).not.toHaveBeenCalled();
+  });
+
+  it('uses pre-GLOAS path for both headers when forkName is fulu', async () => {
+    const { service, consensus, provider } = setupService(SupportedFork.fulu);
+    await service.processBlockRoot(prevHeader, finalizedHeader);
+    expect(consensus.getStateElBlockInfo).not.toHaveBeenCalled();
+    expect(provider.getBlock).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves both headers concurrently via Promise.all', async () => {
+    const order: string[] = [];
+    const consensus = makeConsensusMock();
+    const provider = makeProviderMock();
+    const prometheus = makePrometheus();
+    const prover = { handleBlock: jest.fn() };
+
+    consensus.getBlockInfo.mockImplementation(async (root: string) => {
+      order.push(`getBlockInfo:${root}`);
+      return { block: makeBlockWithExecutionPayload('0x' + 'cc'.repeat(32)), forkName: SupportedFork.fulu };
+    });
+    provider.getBlock.mockImplementation(async () => {
+      order.push('getBlock');
+      return { number: 100 };
+    });
+
+    const service = new (RootsProcessor as any)(
+      makeLogger(), {}, prometheus, consensus,
+      { get: jest.fn(), set: jest.fn() }, prover, provider, {},
+    ) as any;
+
+    await service.processBlockRoot(prevHeader, finalizedHeader);
+
+    // Both getBlockInfo calls should start before either resolves (concurrent)
+    // Verify both roots were fetched
+    expect(order.filter((e) => e.startsWith('getBlockInfo')).length).toBe(2);
+    expect(prover.handleBlock).toHaveBeenCalled();
+  });
+
+  it('propagates errors from resolveElBlockInfo', async () => {
+    const consensus = makeConsensusMock();
+    consensus.getBlockInfo.mockRejectedValue(new Error('CL network error'));
+    const service = makeService(consensus);
+
+    await expect(service.processBlockRoot(prevHeader, finalizedHeader)).rejects.toThrow('CL network error');
+  });
+
+  it('propagates errors from prover.handleBlock', async () => {
+    const { service, prover } = setupService(SupportedFork.fulu);
+    prover.handleBlock.mockRejectedValue(new Error('proof failure'));
+
+    await expect(service.processBlockRoot(prevHeader, finalizedHeader)).rejects.toThrow('proof failure');
+  });
+});

--- a/src/daemon/services/roots-processor.ts
+++ b/src/daemon/services/roots-processor.ts
@@ -58,11 +58,6 @@ export class RootsProcessor {
    */
   private async processBlockRoot(prevHeader: BlockHeaderResponse, finalizedHeader: BlockHeaderResponse): Promise<void> {
     const processingStartTime = Date.now();
-
-    // Resolve EL block info for both CL checkpoints.
-    // Post-ePBS (GLOAS): execution_payload is absent from BeaconBlockBody.
-    // Use state.latestExecutionPayloadHeader (last *revealed* EL block, slot N-1) instead,
-    // which guarantees deposit symmetry with the CL state.
     const [prevElInfo, finalizedElInfo] = await Promise.all([
       this.resolveElBlockInfo(prevHeader),
       this.resolveElBlockInfo(finalizedHeader),
@@ -113,11 +108,6 @@ export class RootsProcessor {
     }
   }
 
-  /**
-   * Resolve EL block hash and number for a given CL block header.
-   * - Pre-ePBS: reads executionPayload from the block body, then fetches EL block number.
-   * - Post-ePBS (GLOAS): reads latestExecutionPayloadHeader from beacon state directly.
-   */
   private async resolveElBlockInfo(header: BlockHeaderResponse): Promise<{ blockHash: string; blockNumber: number }> {
     const { block, forkName } = await this.consensus.getBlockInfo(header.root);
 

--- a/src/daemon/services/roots-processor.ts
+++ b/src/daemon/services/roots-processor.ts
@@ -10,7 +10,7 @@ import { serializeError } from '../../common/logger/safe-error-format';
 import { PrometheusService, TrackTask } from '../../common/prometheus';
 import { getSizeRangeCategory } from '../../common/prometheus/decorators';
 import { ProverService } from '../../common/prover/prover.service';
-import { Consensus } from '../../common/providers/consensus/consensus';
+import { Consensus, SupportedFork } from '../../common/providers/consensus/consensus';
 import { BlockHeaderResponse } from '../../common/providers/consensus/response.interface';
 
 @Injectable()
@@ -59,15 +59,17 @@ export class RootsProcessor {
   private async processBlockRoot(prevHeader: BlockHeaderResponse, finalizedHeader: BlockHeaderResponse): Promise<void> {
     const processingStartTime = Date.now();
 
-    // CL blocks handling
-    const prevBlock = await this.consensus.getBlockInfo(prevHeader.root);
-    const finalizedBlock = await this.consensus.getBlockInfo(finalizedHeader.root);
-    const prevBlockHash = hexlify(prevBlock.body.executionPayload.blockHash);
-    const finalizedBlockHash = hexlify(finalizedBlock.body.executionPayload.blockHash);
+    // Resolve EL block info for both CL checkpoints.
+    // Post-ePBS (GLOAS): execution_payload is absent from BeaconBlockBody.
+    // Use state.latestExecutionPayloadHeader (last *revealed* EL block, slot N-1) instead,
+    // which guarantees deposit symmetry with the CL state.
+    const [prevElInfo, finalizedElInfo] = await Promise.all([
+      this.resolveElBlockInfo(prevHeader),
+      this.resolveElBlockInfo(finalizedHeader),
+    ]);
 
-    // EL blocks handling
-    const prevBlockNumber = (await this.provider.getBlock(prevBlockHash)).number;
-    const finalizedBlockNumber = (await this.provider.getBlock(finalizedBlockHash)).number;
+    const prevBlockNumber = prevElInfo.blockNumber;
+    const finalizedBlockNumber = finalizedElInfo.blockNumber;
 
     const blockRange = finalizedBlockNumber - prevBlockNumber;
     const rangeSizeCategory = getSizeRangeCategory(blockRange);
@@ -109,6 +111,23 @@ export class RootsProcessor {
     } finally {
       stopBlockRangeTimer();
     }
+  }
+
+  /**
+   * Resolve EL block hash and number for a given CL block header.
+   * - Pre-ePBS: reads executionPayload from the block body, then fetches EL block number.
+   * - Post-ePBS (GLOAS): reads latestExecutionPayloadHeader from beacon state directly.
+   */
+  private async resolveElBlockInfo(header: BlockHeaderResponse): Promise<{ blockHash: string; blockNumber: number }> {
+    const { block, forkName } = await this.consensus.getBlockInfo(header.root);
+
+    if (forkName === SupportedFork.gloas) {
+      return this.consensus.getStateElBlockInfo(header.header.message.state_root);
+    }
+
+    const blockHash = hexlify((block as any).body.executionPayload.blockHash);
+    const blockNumber = (await this.provider.getBlock(blockHash)).number;
+    return { blockHash, blockNumber };
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6904,6 +6904,11 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-git-hooks@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz#a2cb8b2dec39703e6c69f982ed1d9fdf444ca8c6"
+  integrity sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"


### PR DESCRIPTION
Summary

  Adds support for the Gloas fork, where `executionPayload` is no longer present directly in the block body.

  - `gloas` added to `SupportedFork` enum and `SupportedBlock` union type
  - `getBlockInfo` now returns `{ block, forkName }` instead of just the block, so callers can branch on fork
  - New `getStateElBlockInfo` method fetches EL block hash and number from the beacon state's `latestExecutionPayloadHeader` — used for Gloas  blocks
  - `resolveElBlockInfo` helper in RootsProcessor encapsulates the fork-specific logic: Gloas goes via beacon state, all other forks use  the block body's executionPayload as before