### PR TITLE
Release 1.0.6 — fix exit request decoding for dataFormat 2

### DIFF
--- a/src/common/prover/prover.service.spec.ts
+++ b/src/common/prover/prover.service.spec.ts
@@ -166,3 +166,92 @@ describe('ProverService.processValidator - exit epoch filtering', () => {
     );
   });
 });
+
+// ─── decodeValidatorsData ─────────────────────────────────────────────────────
+
+describe('ProverService.decodeValidatorsData', () => {
+  const decode = (hex: string, dataFormat: number) => (makeService() as any).decodeValidatorsData(hex, dataFormat);
+
+  // Real tx 0xaa8dad0ec045cf251ed2c530e25c139dd71bd6dea35a99230715a40ae613b822
+  // submitReportData on Hoodi (chain 559024), block 2894999
+  // dataFormat=2 (DATA_FORMAT_LIST_WITH_KEY_INDEX), requestsCount=1
+  const REAL_TX_DATA_FORMAT_2 =
+    '0x' +
+    '000001' + // moduleId = 1  (3 bytes)
+    '0000000007' + // nodeOpId = 7  (5 bytes)
+    '0000000000103f8e' + // validatorIndex = 1064846  (8 bytes)
+    '0000000000000009' + // keyIndex = 9  (8 bytes)  ← format-2 extra field
+    'ae2fd379751dc0256d7ea54eca4d14f8456aec60bcd55397f17f2f01fee04381f5ee7c388ef1bcf0a53f9c5520798eba'; // pubkey (48 bytes)
+
+  it('format 2: correctly decodes the 72-byte real-world entry (regression for BigInt crash)', () => {
+    const entries = decode(REAL_TX_DATA_FORMAT_2, 2);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      exitDataIndex: 0,
+      moduleId: BigInt(1),
+      nodeOpId: BigInt(7),
+      validatorIndex: BigInt(1064846),
+      validatorPubkey:
+        '0xae2fd379751dc0256d7ea54eca4d14f8456aec60bcd55397f17f2f01fee04381f5ee7c388ef1bcf0a53f9c5520798eba',
+    });
+  });
+
+  it('format 2: old ENTRY_SIZE=64 code would have thrown "Cannot convert 0x to a BigInt"', () => {
+    // Manually reproduce the old broken behaviour so the regression is documented
+    const hex = REAL_TX_DATA_FORMAT_2.slice(2); // strip 0x
+    const data = Buffer.from(hex, 'hex');
+    expect(data.byteLength).toBe(72);
+
+    const ENTRY_SIZE_OLD = 64;
+    const entries = [];
+    for (let offset = 0; offset < data.byteLength; offset += ENTRY_SIZE_OLD) {
+      const entry = data.subarray(offset, offset + ENTRY_SIZE_OLD);
+      if (offset > 0) {
+        // second iteration: entry is 8 bytes, subarray(8,16) is empty → BigInt crash
+        expect(entry.subarray(8, 16).toString('hex')).toBe('');
+        expect(() => BigInt('0x' + entry.subarray(8, 16).toString('hex'))).toThrow(SyntaxError);
+        break;
+      }
+      entries.push(entry);
+    }
+  });
+
+  it('format 2: correctly assigns exitDataIndex when multiple 72-byte entries are present', () => {
+    // Two identical entries back-to-back
+    const single = REAL_TX_DATA_FORMAT_2.slice(2); // strip 0x
+    const twoEntries = '0x' + single + single;
+
+    const entries = decode(twoEntries, 2);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].exitDataIndex).toBe(0);
+    expect(entries[1].exitDataIndex).toBe(1);
+    expect(entries[1].moduleId).toBe(BigInt(1));
+  });
+
+  it('format 1: correctly decodes a 64-byte entry (existing behaviour unchanged)', () => {
+    // Build a format-1 entry (no keyIndex field)
+    const moduleId = '000001'; // 3 bytes
+    const nodeOpId = '0000000007'; // 5 bytes
+    const validatorIndex = '0000000000103f8e'; // 8 bytes
+    const pubkey = 'ab'.repeat(48); // 48 bytes
+    const hex = '0x' + moduleId + nodeOpId + validatorIndex + pubkey;
+
+    const entries = decode(hex, 1);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].moduleId).toBe(BigInt(1));
+    expect(entries[0].nodeOpId).toBe(BigInt(7));
+    expect(entries[0].validatorIndex).toBe(BigInt(1064846));
+    expect(entries[0].validatorPubkey).toBe('0x' + pubkey);
+  });
+
+  it('throws for unsupported data formats', () => {
+    expect(() => decode('0x', 3)).toThrow('Unsupported data format: 3');
+    expect(() => decode('0x', 0)).toThrow('Unsupported data format: 0');
+  });
+
+  it('returns empty array for empty data in any supported format', () => {
+    expect(decode('0x', 1)).toEqual([]);
+    expect(decode('0x', 2)).toEqual([]);
+  });
+});

--- a/src/common/prover/prover.service.ts
+++ b/src/common/prover/prover.service.ts
@@ -638,7 +638,10 @@ export class ProverService implements OnModuleInit {
         `\n  Data Format: ${exitRequest.exitRequestsData.dataFormat}`,
     );
 
-    const validators = this.decodeValidatorsData(exitRequest.exitRequestsData.data);
+    const validators = this.decodeValidatorsData(
+      exitRequest.exitRequestsData.data,
+      exitRequest.exitRequestsData.dataFormat,
+    );
     const deliveredTimestamp = await this.exitRequests.getExitRequestDeliveryTimestamp(exitRequest.exitRequestsHash);
 
     this.loggerService.log(
@@ -1291,13 +1294,21 @@ export class ProverService implements OnModuleInit {
     return validatorsByDeadlineSlot;
   }
 
-  private decodeValidatorsData(encodedHex: string): {
+  private decodeValidatorsData(
+    encodedHex: string,
+    dataFormat: number = 1,
+  ): {
     exitDataIndex: number;
     moduleId: bigint;
     nodeOpId: bigint;
     validatorIndex: bigint;
     validatorPubkey: string;
   }[] {
+    // DATA_FORMAT_LIST (1):          64 bytes/entry: moduleId(3) + nodeOpId(5) + validatorIndex(8) + pubkey(48)
+    // DATA_FORMAT_LIST_WITH_KEY_INDEX (2): 72 bytes/entry: moduleId(3) + nodeOpId(5) + validatorIndex(8) + keyIndex(8) + pubkey(48)
+    const DATA_FORMAT_LIST = 1;
+    const DATA_FORMAT_LIST_WITH_KEY_INDEX = 2;
+
     // Remove '0x' prefix if present
     if (encodedHex.startsWith('0x')) {
       encodedHex = encodedHex.slice(2);
@@ -1305,7 +1316,19 @@ export class ProverService implements OnModuleInit {
 
     const data = Buffer.from(encodedHex, 'hex');
 
-    const ENTRY_SIZE = 64;
+    let ENTRY_SIZE: number;
+    let PUBKEY_OFFSET: number;
+
+    if (dataFormat === DATA_FORMAT_LIST_WITH_KEY_INDEX) {
+      ENTRY_SIZE = 72;
+      PUBKEY_OFFSET = 24; // moduleId(3) + nodeOpId(5) + validatorIndex(8) + keyIndex(8) = 24
+    } else if (dataFormat === DATA_FORMAT_LIST) {
+      ENTRY_SIZE = 64;
+      PUBKEY_OFFSET = 16; // moduleId(3) + nodeOpId(5) + validatorIndex(8) = 16
+    } else {
+      throw new Error(`Unsupported data format: ${dataFormat}`);
+    }
+
     const entries: {
       exitDataIndex: number;
       moduleId: bigint;
@@ -1321,7 +1344,7 @@ export class ProverService implements OnModuleInit {
       const moduleId = BigInt('0x' + entry.subarray(0, 3).toString('hex'));
       const nodeOpId = BigInt('0x' + entry.subarray(3, 8).toString('hex'));
       const validatorIndex = BigInt('0x' + entry.subarray(8, 16).toString('hex'));
-      const validatorPubkey = '0x' + entry.subarray(16, 64).toString('hex');
+      const validatorPubkey = '0x' + entry.subarray(PUBKEY_OFFSET, PUBKEY_OFFSET + 48).toString('hex');
 
       entries.push({
         exitDataIndex,


### PR DESCRIPTION
Promotes `develop` to `main` for release **1.0.6**. Single functional change: correct decoding of VEBO exit request payloads submitted with `dataFormat = 2` (`DATA_FORMAT_LIST_WITH_KEY_INDEX`). Ships #35.

## Why now

The mainnet daemon is currently wedged on this bug. It fails every cycle while processing the same block range, so `lastProcessedRoot` never advances and no exit-delay proofs are being submitted:

```
[error] [Blocks 25639883-25651329] Processing failed:  Error: Error: Invalid tree - found leaf at depth 2
[error] Failed to process root [0x25a6d2baebf923fa507f8e3e561f3652ec49458006c94756918c2f0ace6812b0]
```

The pinned range start (block 25639883) puts the first failure at roughly 2026-07-29 ~19:30 UTC. The fix has been running on Hoodi since 2026-05-27.

## Root cause

`decodeValidatorsData` hardcoded a 64-byte entry stride:

| format | entry layout | size |
|---|---|---|
| 1 — `DATA_FORMAT_LIST` | `moduleId(3) + nodeOpId(5) + validatorIndex(8) + pubkey(48)` | 64 B |
| 2 — `DATA_FORMAT_LIST_WITH_KEY_INDEX` | `moduleId(3) + nodeOpId(5) + validatorIndex(8) + keyIndex(8) + pubkey(48)` | **72 B** |

Parsing 72-byte entries at a 64-byte stride shifts every entry after the first by 8 bytes. The visible symptom depends on how many requests the report contains:

- **1 request** (72 B) — the trailing 8-byte fragment leaves `subarray(8, 16)` empty → `BigInt('0x')` → `SyntaxError: Cannot convert 0x to a BigInt`. This is what was seen on Hoodi and what the regression test pins.
- **≥ 2 requests** — iteration 1 reads bytes 72–80, which is entry 1's `moduleId(3) | nodeOpId(5)` header. As a big-endian uint64 that equals `moduleId · 2^40 + nodeOpId`, so for module 1 it lands in `[2^40, 2^41)`. `VALIDATOR_REGISTRY_LIMIT` is `2^40`, so the SSZ gindex for that index navigates right from the `validators` list root into the length leaf and `getNode` throws `Invalid tree - found leaf at depth 2`. This is the mainnet symptom.

Same defect, two faces — the fix covers both.

## Changes

- `decodeValidatorsData(encodedHex, dataFormat = 1)` derives `ENTRY_SIZE` and `PUBKEY_OFFSET` from the format, and throws on an unrecognised format instead of mis-parsing it.
- `processExitRequest` now passes `exitRequest.exitRequestsData.dataFormat` through.
- Unit tests for format 2 (built from real Hoodi tx `0xaa8dad0ec045cf251ed2c530e25c139dd71bd6dea35a99230715a40ae613b822`, block 2894999), multi-entry `exitDataIndex` assignment, the documented old failure mode, and format 1 unchanged.

## Risk

Low. Format 1 keeps identical offsets, so existing behaviour is byte-for-byte unchanged, and format 1 payloads make up everything processed to date on mainnet. The one behaviour change is that an unrecognised `dataFormat` now raises instead of silently decoding garbage — louder and correct, but note that a future unknown format would stop the daemon rather than skip the request (see follow-ups).

## Rollout

1. Merge with a **merge commit** (not squash — squashing a `develop → main` PR detaches the branch histories; see `fe9746f` / the `stitch-develop-base` repair).
2. **Do not back-merge `main` → `develop`.** A ruleset on `develop` enforces linear history (`This branch must not contain merge commits`) and PR-only changes, so the back-merge is unpushable — both of GitHub's "Update branch" modes are blocked (merge violates linear history, rebase needs a force-push that `non_fast_forward` rejects). It is also unnecessary: the only commit in `main` that is not in `develop` is the release merge commit itself, and `main`'s tree at `59d102a` is byte-identical to `develop`'s at `50ddda2` (`b360ba48`) — no content is stranded. Skipping the back-merge leaves `merge-base(main, develop)` at `eeb59cc`, so the next release PR shows only new `develop` work and the criss-cross in `main`'s graph stops growing.
3. Publish release **1.0.6** to trigger the prod image build (`ci-prod.yml`).
4. On mainnet redeploy the daemon restarts with an empty in-memory `lastProcessedRoot` and re-scans from `START_LOOKBACK_DAYS`, which re-processes the previously poisoned block range with the correct parser.

Note for future hotfixes: with linear history enforced on `develop`, anything landed directly on `main` (as `1f7d995`, `949f026`, `3d8ed00` were) can only reach `develop` by cherry-pick in a PR — never by merge.

## Follow-ups (not in this PR)

- Reject payloads where `data.length % ENTRY_SIZE !== 0` instead of decoding a truncated tail.
- Bounds-check `validatorIndex` against `stateView.validators.length` before `getReadonly` — an out-of-range index currently surfaces as an opaque SSZ tree error (or a silent stub view for `length ≤ i < 2^40`) with no exit-request context in the log.
- Isolate failures per exit request so one undecodable payload cannot pin the daemon indefinitely; count them in a metric.
- Alert on `data_actuality` / last-processed-slot lag — this incident ran unnoticed for ~38 h.

