### PR TITLE
fix: skip missed slots when computing EIP-4788 roots timestamp

### DIFF
--- a/src/common/prover/prover.service.spec.ts
+++ b/src/common/prover/prover.service.spec.ts
@@ -1,4 +1,5 @@
 import { ProverService } from './prover.service';
+import { RequestError } from '../providers/base/rest-provider';
 
 // Minimal prometheus mock covering every counter/timer used in processValidator
 const makePrometheusMock = () => ({
@@ -253,5 +254,66 @@ describe('ProverService.decodeValidatorsData', () => {
   it('returns empty array for empty data in any supported format', () => {
     expect(decode('0x', 1)).toEqual([]);
     expect(decode('0x', 2)).toEqual([]);
+  });
+});
+
+// ─── calcRootsTimestamp — EIP-4788 lookup key ─────────────────────────────────
+
+// Hoodi (chain 560048) constants, taken from the network that produced the RootNotFound() incident
+const HOODI_GENESIS = 1742213400;
+const SECONDS_PER_SLOT = 12;
+
+// Real Hoodi history around the failing proof: slot 3624534 was never proposed, so the block root
+// of slot 3624533 was stored by the block at slot 3624535 under its own timestamp.
+const PROVABLE_SLOT = 3624533;
+const MISSED_SLOT = 3624534;
+const NEXT_PROPOSED_SLOT = 3624535;
+
+const missedSlots = (missed: number[]) =>
+  jest.fn(async (blockId: string) => {
+    if (missed.includes(Number(blockId))) {
+      throw new RequestError(`NOT_FOUND: beacon block at slot ${blockId}`, 404);
+    }
+    return { header: { message: { slot: blockId } } };
+  });
+
+const makeHoodiService = (getBeaconHeader: jest.Mock) =>
+  makeService({
+    consensus: {
+      genesisTimestamp: HOODI_GENESIS,
+      beaconConfig: { SLOTS_PER_EPOCH: 32, SECONDS_PER_SLOT },
+      slotToTimestamp: (slot: number) => HOODI_GENESIS + slot * SECONDS_PER_SLOT,
+      getBeaconHeader,
+    },
+  });
+
+describe('ProverService.calcRootsTimestamp', () => {
+  it('skips a missed slot and keys on the next proposed slot (regression for RootNotFound)', async () => {
+    const service = makeHoodiService(missedSlots([MISSED_SLOT]));
+
+    const rootsTimestamp = await (service as any).calcRootsTimestamp(PROVABLE_SLOT);
+
+    // Timestamp of slot 3624535 - the block that actually stored the slot-3624533 root.
+    // Verified on Hoodi: BEACON_ROOTS.get(1785707820) == 0x37350b7f...3702a00c
+    expect(rootsTimestamp).toBe(1785707820);
+    // The old `genesis + (slot + 1) * SECONDS_PER_SLOT` formula produced this, and the beacon roots
+    // predeploy reverts on it because no execution block carries a missed slot's timestamp.
+    expect(rootsTimestamp).not.toBe(1785707808);
+  });
+
+  it('keys on slot + 1 when that slot was proposed', async () => {
+    const service = makeHoodiService(missedSlots([]));
+
+    const rootsTimestamp = await (service as any).calcRootsTimestamp(PROVABLE_SLOT);
+
+    expect(rootsTimestamp).toBe(HOODI_GENESIS + (PROVABLE_SLOT + 1) * SECONDS_PER_SLOT);
+  });
+
+  it('skips a run of consecutive missed slots', async () => {
+    const service = makeHoodiService(missedSlots([MISSED_SLOT, NEXT_PROPOSED_SLOT, NEXT_PROPOSED_SLOT + 1]));
+
+    const rootsTimestamp = await (service as any).calcRootsTimestamp(PROVABLE_SLOT);
+
+    expect(rootsTimestamp).toBe(HOODI_GENESIS + (NEXT_PROPOSED_SLOT + 2) * SECONDS_PER_SLOT);
   });
 });

--- a/src/common/prover/prover.service.ts
+++ b/src/common/prover/prover.service.ts
@@ -596,7 +596,7 @@ export class ProverService implements OnModuleInit {
         stateRoot: finalizedBlockHeader.header.message.state_root,
         bodyRoot: finalizedBlockHeader.header.message.body_root,
       },
-      rootsTimestamp: this.calcRootsTimestamp(finalizedSlot),
+      rootsTimestamp: await this.calcRootsTimestamp(finalizedSlot),
     };
     const ssz = await eval(`import('@lodestar/types').then((m) => m.ssz)`);
 
@@ -765,7 +765,7 @@ export class ProverService implements OnModuleInit {
         stateRoot: deadlineBlockHeader.header.message.state_root,
         bodyRoot: deadlineBlockHeader.header.message.body_root,
       },
-      rootsTimestamp: this.calcRootsTimestamp(actualSlot),
+      rootsTimestamp: await this.calcRootsTimestamp(actualSlot),
     };
 
     // Process all combined validators for this deadline slot
@@ -1376,12 +1376,18 @@ export class ProverService implements OnModuleInit {
     return slot % slotsPerHistoricalRoot;
   }
 
-  private calcRootsTimestamp(slot: number): number {
-    return (
-      this.consensus.genesisTimestamp +
-      Number(this.consensus.beaconConfig.SECONDS_PER_SLOT) +
-      slot * Number(this.consensus.beaconConfig.SECONDS_PER_SLOT)
-    );
+  /**
+   * Timestamp under which the EIP-4788 beacon roots predeploy stores the block root of `slot`.
+   *
+   * The root of slot N is written by the next block that is *actually proposed*, keyed by that
+   * block's own timestamp. Assuming that block sits at slot N+1 is wrong: when N+1 is a missed
+   * slot no execution block carries its timestamp, the ring buffer holds no entry for it, and the
+   * verifier reverts with RootNotFound(). Scan forward for the first slot after `slot` that has a
+   * block instead - its parent is `slot`, so it is the block that stored the root.
+   */
+  private async calcRootsTimestamp(slot: number): Promise<number> {
+    const { slot: rootsSlot } = await this.findNextAvailableSlot(slot + 1);
+    return this.consensus.slotToTimestamp(rootsSlot);
   }
 
   /**


### PR DESCRIPTION
## Problem

Production logs from 2026-08-03 (Hoodi):

```
verifyValidatorExitDelay(...) errorName="RootNotFound" data="0x3033b0ff"
[Blocks 3046593-3343347] ❌ Batch 1/6 failed: Validators: 20, Block slot: 3624533
```

The revert repeated every cycle and failed the `roots-processing` task.

## Root cause

`calcRootsTimestamp` computed the EIP-4788 lookup key as `genesis + (slot + 1) * SECONDS_PER_SLOT`, i.e. it assumed a block exists at slot `N+1`.

The beacon roots predeploy stores the root of slot `N` under the timestamp of the **next block that is actually proposed**. When `N+1` is a missed slot, no execution block carries that timestamp, the ring buffer holds no entry for it, and the verifier reverts with `RootNotFound()`.

`findNextAvailableSlot` already skipped forward to a slot that *has* a block, but nothing checked that the slot *after* it also has one.

## On-chain verification (Hoodi, chain 560048)

| check | result |
|---|---|
| CL header, slot 3624533 | exists, root `0x37350b7f…3702a00c` |
| CL header, slot **3624534** | **404 — missed slot** |
| CL header, slot 3624535 | exists, EL timestamp `1785707820` |
| `BEACON_ROOTS.get(1785707808)` ← what the bot sent | **execution reverted** → `RootNotFound()` |
| `BEACON_ROOTS.get(1785707820)` ← next proposed slot | `0x37350b7f…3702a00c`, exactly the slot-3624533 root |

Ruled out the alternative explanation (slot aged out of the ring buffer): the slot was 11.6 h old when the error fired, and the buffer covers ~27.3 h.

## Fix

`calcRootsTimestamp` now resolves the first slot after the target that has a block and keys on its timestamp. Applied at both call sites — the deadline header (the one that reverted) and the finalized header used as the historical-proof anchor, where the same bug was latent.

## Tests

3 regression tests pinned to the real Hoodi values, including an explicit assertion that the result is *not* `1785707808`.

Dry run over the same deadline slot:

```
Found available slot 3624535 (requested: 3624534, skipped: 1)
Validators in batch: 34
✅ Emulated call succeeded
📊 Estimated gas: 3,109,220
✅ DRY RUN completed successfully - no transaction sent
✅ Successfully processed root [0x359c956e…] at slot [3628480]
```

