### PR TITLE
chore(deps): aggregate the open dependabot bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "stream-chain": "^2.2.5",
     "stream-json": "^1.8.0",
     "typechain": "^8.3.2",
-    "undici": "^6.21.1",
+    "undici": "^6.23.0",
     "winston": "^3.11.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7639,10 +7639,10 @@ undici-types@~7.13.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz#a20ba7c0a2be0c97bd55c308069d29d167466bff"
   integrity sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==
 
-undici@^6.21.1:
-  version "6.21.3"
-  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
-  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
+undici@^6.23.0:
+  version "6.28.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -7726,9 +7726,9 @@ v8-to-istanbul@^9.0.1:
     convert-source-map "^2.0.0"
 
 validator@^13.9.0:
-  version "13.15.15"
-  resolved "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz#246594be5671dc09daa35caec5689fcd18c6e7e4"
-  integrity sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==
+  version "13.15.35"
+  resolved "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz#81cf455c51f15b69d8d340be5914f3fab00dbf7f"
+  integrity sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Aggregates the six open dependabot PRs into one: #27, #23, #5, #4, #3, #2.

Regenerated with yarn against current `develop` rather than merged, so the lockfile stays internally consistent — the four older branches were opened when the repo used the Yarn Berry lockfile format and carry `@npm:`/`patch:` entries that no longer apply to the Yarn 1 lockfile on `develop`.

## What actually changes

| package | on develop | after | dependabot asked for |
|---|---|---|---|
| `undici` | 6.21.3 | **6.28.0** | 6.23.0 (#27) |
| `validator` | 13.15.15 | **13.15.35** | 13.15.23 (#23) |

`undici` is a direct dependency, so its floor moves to `^6.23.0` exactly as #27 proposed and the lockfile resolves higher within that range. `validator` comes in transitively through `class-validator`, so only its lockfile entry changes.

## Already satisfied on develop

These four need no change — `develop` has moved past them since the PRs were opened:

| package | required | on develop |
|---|---|---|
| `form-data` (#5) | 4.0.4 | 4.0.4 |
| `brace-expansion` (#4) | 1.1.12 | 1.1.12 (`^1` range), 2.0.2 (`^2` range) |
| `formidable` (#3) | 2.1.5 | 2.1.5 |
| `@nestjs/common` (#2) | 10.4.16 | 10.4.20 |

## Testing

`yarn lint`, `tsc --noEmit`, `yarn test` (27 tests / 2 suites) and `yarn build` all pass on the resulting tree.

Once this is merged, #27, #23, #5, #4, #3 and #2 can be closed.
